### PR TITLE
Initialise JOBID to be equal to $1

### DIFF
--- a/jobs/psjob
+++ b/jobs/psjob
@@ -22,6 +22,8 @@ then
 	exit -1
 fi
 
+JOBID="${1}"
+
 # System users excluded from the list
 # The "68" is haldaemon on CentOS6 as printed by ps.
 USERLIST="root rpc rpcuser daemon ntp smmsp sshd hpsmh named dbus 68 chrony polkitd munge"


### PR DESCRIPTION
This script did not work for me as `$JOBID` does not seem to be defined at all ; it complained that `The job is not running, it has state=JobState=PENDING JobState=PENDING JobState=PENDING ...` with the list of states for all jobs in the system.