### PR TITLE
Improve report output names

### DIFF
--- a/slurmacct/slurmacct
+++ b/slurmacct/slurmacct
@@ -36,7 +36,7 @@ EOF
 #####################################################################################
 
 # Report file prefix
-REPORT_PREFIX=/tmp/Slurm_report_acct
+REPORT_PREFIX=/tmp/Slurm_report_acct_
 export partition=""
 export username=""
 export groupname=""

--- a/slurmacct/slurmacct
+++ b/slurmacct/slurmacct
@@ -36,7 +36,7 @@ EOF
 #####################################################################################
 
 # Report file prefix
-REPORT_PREFIX=/tmp/Slurm_report
+REPORT_PREFIX=/tmp/Slurm_report_acct
 export partition=""
 export username=""
 export groupname=""

--- a/slurmreportmonth/slurmreportmonth
+++ b/slurmreportmonth/slurmreportmonth
@@ -9,7 +9,7 @@
 export SEND_EMAIL=0
 SUBSCRIBERS=root@localhost
 # Report file prefix
-REPORT_PREFIX=/tmp/Slurm_report_month
+REPORT_PREFIX=/tmp/Slurm_report_month_
 # Change the date/time format in report header for readability (formats in "man strftime")
 export SLURM_TIME_FORMAT="%d-%b-%Y_%R"
 # End of CONFIGURE lines

--- a/slurmreportmonth/slurmreportmonth
+++ b/slurmreportmonth/slurmreportmonth
@@ -9,7 +9,7 @@
 export SEND_EMAIL=0
 SUBSCRIBERS=root@localhost
 # Report file prefix
-REPORT_PREFIX=/tmp/Slurm_report
+REPORT_PREFIX=/tmp/Slurm_report_month
 # Change the date/time format in report header for readability (formats in "man strftime")
 export SLURM_TIME_FORMAT="%d-%b-%Y_%R"
 # End of CONFIGURE lines


### PR DESCRIPTION
Very minor changes but helpful for discerning the type of report.
Previously only distinguishable via a "."
```

eg previously
Slurm_report.August_2021
Slurm_reportAugust_2021

now

Slurm_report_acct_August_2021
Slurm_report_month_August_2021

```
