### PR TITLE
Reserve more nodes

### DIFF
--- a/nodes/README.md
+++ b/nodes/README.md
@@ -8,7 +8,7 @@ Some convenient scripts for working with nodes (or lists of nodes):
 * Drain a node-list: ```sdrain node-list "Reason"```.
 * Resume a node-list: ```sresume node-list```.
 * Reboot and resume a node-list: ```sreboot node-list```.
-* Reserve nodes when they become idle: ```reserve_on_idle [-k|--keep-reservation] [-d|--duration DURATION] "<node-list>" "<reason>"```.
+* Reserve nodes when they become idle: ```reserve_on_idle [-s|--single-reservation] [-k|--keep-reservation] [-d|--duration DURATION] "<node-list>"```.
 * Show node status: ```shownode <node-list>```.
 * Power up/down a node-list: ```spowerup node-list``` and ```spowerdown node-list```.
   Note: This only works with nodes in Slurm power saving, NOT nodes in state DOWN, DRAIN etc.
@@ -71,8 +71,9 @@ clush -bw <node-list> 'echo "@reboot root /bin/bash /root/update.sh" >> /etc/cro
 
 If nodes in the node-list are in non-exclusive partitions, run ```reserve_on_idle``` to create a reservation for each node starting when its last currently running job is expected to finish. This allows Slurm backfill to schedule new jobs only if they can finish before the reservation begins:
 ```
-reserve_on_idle <node-list> UPDATE
+reserve_on_idle <node-list>
 ```
+Use ```-s``` or ```--single-reservation``` to create one reservation for the full node-list instead. The single reservation starts when the last job across all requested nodes is expected to finish, and implies ```--keep-reservation```.
 
 Then schedule the nodes for reboot through Slurm as soon as they become idle, and set their next state to DOWN:
 ```

--- a/nodes/reserve_on_idle
+++ b/nodes/reserve_on_idle
@@ -4,8 +4,15 @@
 # This is useful for e.g. updating non-exclusive nodes so the nodes are not blocked while waiting for the last job to end. 
 # The reservation is needed to allow backfill to schedule jobs that end before the reservation expires. 
 # The reservation should then be removed by update.sh after the reboot.
+#
+# By default, one reservation is created per node, each starting when that node's
+# last currently running job is expected to end. With -s/--single-reservation,
+# one reservation is created for all requested nodes, starting when the last job
+# across all requested nodes is expected to end. This implies
+# -k/--keep-reservation because update.sh removes per-node reservations named
+# update-<node>.
 
-# Usage: reserve_on_idle [-k|--keep-reservation] [-d|--duration DURATION] "<NODES>" "<REASON>"
+# Usage: reserve_on_idle [-s|--single-reservation] [-k|--keep-reservation] [-d|--duration DURATION] "<NODES>"
 
 # Dependency: The nodeset command from ClusterShell is required.
 
@@ -26,21 +33,27 @@ err(){ echo "Error: $*" >&2; exit 1; }
 info(){ echo "[info] $*"; }
 usage(){
     cat <<EOF
-Usage: $0 [-k|--keep-reservation] [-d|--duration DURATION] "<NODES>" "<REASON>"
+Usage: $0 [-s|--single-reservation] [-k|--keep-reservation] [-d|--duration DURATION] "<NODES>"
+  -s, --single-reservation  create one reservation for all nodes; implies -k
   -k, --keep-reservation  update.sh will not delete the reservation
   -d, --duration DURATION  reservation duration (e.g. 08:00:00)
 EOF
 }
 
+single_reservation=false
 keep_reservation=false
 RESERVATION_DURATION="$DEFAULT_RESERVATION_DURATION"
 
 normalized_args=()
-# support long options --keep-reservation, --help, --duration <value> and --duration=VALUE
+# support long options --single-reservation, --keep-reservation, --help,
+# --duration <value> and --duration=VALUE
 args=("$@")
 for ((i=0;i<${#args[@]};i++)); do
     arg="${args[i]}"
     case "$arg" in
+        --single-reservation)
+            normalized_args+=("-s")
+            ;;
         --keep-reservation)
             normalized_args+=("-k")
             ;;
@@ -65,8 +78,11 @@ for ((i=0;i<${#args[@]};i++)); do
 done
 set -- "${normalized_args[@]}"
 
-while getopts ":khd:" opt; do
+while getopts ":skhd:" opt; do
     case "$opt" in
+        s)
+            single_reservation=true
+            ;;
         k)
             keep_reservation=true
             ;;
@@ -90,13 +106,16 @@ done
 
 shift $((OPTIND - 1))
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -ne 1 ]]; then
     usage
-    err "Please provide only NODES and REASON!"
+    err "Please provide only NODES!"
 fi
 
 NODES_EXPR="$1"
-REASON="$2"
+
+if [[ "$single_reservation" == true ]]; then
+    keep_reservation=true
+fi
 
 if [[ "$keep_reservation" == true ]]; then
     RESERVATION_NAME_PREFIX="$KEEP_RESERVATION_NAME_PREFIX"
@@ -116,28 +135,53 @@ readarray -t NODES < <(scontrol show hostnames "$HOSTLIST")
 # We want to undo any custom time formats and just use the default
 # when parsing end times from squeue
 unset SLURM_TIME_FORMAT
-for node in "${NODES[@]}"; do
-    info "Processing node $node ..."
 
-    endtime=$(squeue -h -w $node -O Endtime | sort | tail -1)
-    if [[ -z "$endtime" ]]
+if [[ "$single_reservation" == true ]]; then
+    latest_endtime=$(squeue -h -w "$HOSTLIST" -O Endtime | sort | tail -1)
+    if [[ -z "$latest_endtime" ]]
     then
-        endtime="Now"
-        info "  No jobs on node $node, setting reservation Start = $endtime"
+        latest_endtime="Now"
+        info "No jobs on any selected nodes, setting reservation Start = $latest_endtime"
     fi
 
-    # This magic reservation name is used by update.sh to identify
-    # reservations that should be removed after the reboot
-    res_name="${RESERVATION_NAME_PREFIX}-${node}"
+    # --single-reservation implies --keep-reservation, so this grouped
+    # reservation is not removed automatically by update.sh after reboot.
+    res_name="${RESERVATION_NAME_PREFIX}-${NODES[0]}-single"
 
-    # Create reservation (per node). This lets backfill allow only
-    # jobs that finish before start.
-    info "  Creating reservationname=$res_name starting $endtime for node $node"
+    # Create one reservation for the full node set. This waits for the busiest
+    # selected node to become idle before reserving all requested nodes together.
+    info "Creating reservationname=$res_name starting $latest_endtime for nodes $HOSTLIST"
     scontrol create reservation \
              ReservationName="$res_name" \
-             StartTime="$endtime" \
+             StartTime="$latest_endtime" \
              Duration="$RESERVATION_DURATION" \
-             Nodes="$node" \
+             Nodes="$HOSTLIST" \
              Users=root \
              Flags=MAINT >/dev/null
-done
+else
+    for node in "${NODES[@]}"; do
+        info "Processing node $node ..."
+
+        endtime=$(squeue -h -w "$node" -O Endtime | sort | tail -1)
+        if [[ -z "$endtime" ]]
+        then
+            endtime="Now"
+            info "  No jobs on node $node, setting reservation Start = $endtime"
+        fi
+
+        # This magic reservation name is used by update.sh to identify
+        # reservations that should be removed after the reboot
+        res_name="${RESERVATION_NAME_PREFIX}-${node}"
+
+        # Create reservation (per node). This lets backfill allow only
+        # jobs that finish before start.
+        info "  Creating reservationname=$res_name starting $endtime for node $node"
+        scontrol create reservation \
+                 ReservationName="$res_name" \
+                 StartTime="$endtime" \
+                 Duration="$RESERVATION_DURATION" \
+                 Nodes="$node" \
+                 Users=root \
+                 Flags=MAINT >/dev/null
+    done
+fi

--- a/nodes/reserve_on_idle
+++ b/nodes/reserve_on_idle
@@ -13,6 +13,10 @@
 # update-<node>. Single reservations are named reservation-<folded-nodelist>,
 # with commas and brackets replaced by underscores. If that name is too long,
 # it is compacted to include the first folded segment and node count.
+#
+# Reservations kept after the update workflow may need different reservation
+# settings. Review values such as Users=root and Flags=MAINT before using -k or
+# -s for non-update work.
 
 # Usage: reserve_on_idle [-s|--single-reservation] [-k|--keep-reservation] [-d|--duration DURATION] "<NODES>"
 
@@ -41,6 +45,9 @@ Usage: $0 [-s|--single-reservation] [-k|--keep-reservation] [-d|--duration DURAT
   -s, --single-reservation  create one reservation for all nodes; implies -k
   -k, --keep-reservation  update.sh will not delete the reservation
   -d, --duration DURATION  reservation duration (e.g. 08:00:00)
+
+Reservations kept with -k or -s may need other settings than Users=root
+or Flags=MAINT if they are used for anything other than update.
 EOF
 }
 make_single_reservation_name(){
@@ -149,6 +156,7 @@ fi
 
 if [[ "$keep_reservation" == true ]]; then
     RESERVATION_NAME_PREFIX="$KEEP_RESERVATION_NAME_PREFIX"
+    info "This reservation will not be removed automatically by update.sh. Consider adding users, flags or other settings to the reservation."
 fi
 
 # ---------- sanity checks ----------

--- a/nodes/reserve_on_idle
+++ b/nodes/reserve_on_idle
@@ -10,12 +10,11 @@
 # Dependency: The nodeset command from ClusterShell is required.
 
 # Optional: Set Bash flags:
-# set -euo pipefail
-# -e: exit immediately if any command fails,
+set -uo pipefail
 # -u: treat unset variables as an error, 
 # -o pipefail: the return value of a pipeline is the status of the last command to exit with a non-zero status,
 #    or zero if no command exited with a non-zero status.
-#    This is sometimes called bash strict mode: https://ewus.de/en/hint/bash-strict-mode
+#    Parts of this is sometimes called bash strict mode: https://ewus.de/en/hint/bash-strict-mode
 
 # Configuration: 
 DEFAULT_RESERVATION_DURATION="08:00:00"

--- a/nodes/reserve_on_idle
+++ b/nodes/reserve_on_idle
@@ -10,7 +10,9 @@
 # one reservation is created for all requested nodes, starting when the last job
 # across all requested nodes is expected to end. This implies
 # -k/--keep-reservation because update.sh removes per-node reservations named
-# update-<node>.
+# update-<node>. Single reservations are named reservation-<folded-nodelist>,
+# with commas and brackets replaced by underscores. If that name is too long,
+# it is compacted to include the first folded segment and node count.
 
 # Usage: reserve_on_idle [-s|--single-reservation] [-k|--keep-reservation] [-d|--duration DURATION] "<NODES>"
 
@@ -27,6 +29,8 @@ set -uo pipefail
 DEFAULT_RESERVATION_DURATION="08:00:00"
 RESERVATION_NAME_PREFIX="update"
 KEEP_RESERVATION_NAME_PREFIX="node_reserved"
+SINGLE_RESERVATION_NAME_PREFIX="reservation"
+MAX_RESERVATION_NAME_LENGTH=64
 
 # Functions:
 err(){ echo "Error: $*" >&2; exit 1; }
@@ -38,6 +42,32 @@ Usage: $0 [-s|--single-reservation] [-k|--keep-reservation] [-d|--duration DURAT
   -k, --keep-reservation  update.sh will not delete the reservation
   -d, --duration DURATION  reservation duration (e.g. 08:00:00)
 EOF
+}
+make_single_reservation_name(){
+    local folded_list="$1"
+    local node_count="$2"
+    local safe_list candidate suffix available first_part
+
+    # Keep the folded hostlist readable, but avoid commas and brackets in the
+    # reservation name because they have special meaning in Slurm and shells.
+    safe_list=${folded_list//,/_}
+    safe_list=${safe_list//[/_}
+    safe_list=${safe_list//]/_}
+    safe_list=$(printf '%s' "$safe_list" | sed 's/_\{2,\}/_/g; s/^_//; s/_$//')
+    candidate="${SINGLE_RESERVATION_NAME_PREFIX}-${safe_list}"
+    if (( ${#candidate} <= MAX_RESERVATION_NAME_LENGTH )); then
+        printf '%s\n' "$candidate"
+        return
+    fi
+
+    suffix="-n${node_count}"
+    available=$((MAX_RESERVATION_NAME_LENGTH - ${#SINGLE_RESERVATION_NAME_PREFIX} - 1 - ${#suffix}))
+    if (( available < 1 )); then
+        err "MAX_RESERVATION_NAME_LENGTH is too small for compacted reservation names"
+    fi
+
+    first_part="${safe_list%%_*}"
+    printf '%s\n' "${SINGLE_RESERVATION_NAME_PREFIX}-${first_part:0:$available}${suffix}"
 }
 
 single_reservation=false
@@ -144,9 +174,9 @@ if [[ "$single_reservation" == true ]]; then
         info "No jobs on any selected nodes, setting reservation Start = $latest_endtime"
     fi
 
-    # --single-reservation implies --keep-reservation, so this grouped
-    # reservation is not removed automatically by update.sh after reboot.
-    res_name="${RESERVATION_NAME_PREFIX}-${NODES[0]}-single"
+    # --single-reservation implies --keep-reservation, so this name does not
+    # match the per-node update-<node> names removed by update.sh after reboot.
+    res_name=$(make_single_reservation_name "$HOSTLIST" "${#NODES[@]}")
 
     # Create one reservation for the full node set. This waits for the busiest
     # selected node to become idle before reserving all requested nodes together.

--- a/nodes/update.sh
+++ b/nodes/update.sh
@@ -27,7 +27,7 @@ RPMDIR=$PACKAGEDIR/RPMS8
 #    when the nodes become idle so that the nodes may run other jobs
 #    by Slurm backfilling until they become idle.
 #    The reservation will be automatically deleted as part of the present script.
-#    $ reserve_on_idle <nodelist> update
+#    $ reserve_on_idle <nodelist>
 #
 # 5. Then reboot the nodes with:
 #    $ sreboot -d -r UPDATE <nodelist>
@@ -470,4 +470,3 @@ else
 	echo "Reboot the node immediately"
 	shutdown -r now
 fi
-


### PR DESCRIPTION
Implemented option for creating only a single reservation with all specified nodes (with `-s` or `--single-reservation`). Functionality without this option is unchanged.